### PR TITLE
Fix css-module support in CRA@3.3.0

### DIFF
--- a/packages/craco/lib/features/webpack/style/css.js
+++ b/packages/craco/lib/features/webpack/style/css.js
@@ -1,15 +1,29 @@
 const { getLoaders, loaderByName } = require("../../../loaders");
 const { log, logError } = require("../../../logger");
-const { isFunction, deepMergeWithArray } = require("../../../utils");
+const { isFunction, isBoolean, deepMergeWithArray } = require("../../../utils");
 
 function setModuleLocalIdentName(match, localIdentName) {
-    if (match.loader.options) {
-        delete match.loader.options.getLocalIdent;
-        match.loader.options.localIdentName = localIdentName;
+    // The css-loader version of create-react-app has changed from 2.1.1 to 3.2.0
+    // https://github.com/facebook/create-react-app/commit/f79f30
+    if (isBoolean(match.loader.options.modules)) {
+        if (match.loader.options) {
+            delete match.loader.options.getLocalIdent;
+            match.loader.options.localIdentName = localIdentName;
+        } else {
+            match.loader.options = {
+                localIdentName: localIdentName
+            };
+        }
     } else {
-        match.loader.options = {
-            localIdentName: localIdentName
-        };
+        // This setting applies to create-react-app@3.3.0
+        if (match.loader.options) {
+            delete match.loader.options.modules.getLocalIdent;
+            match.loader.options.modules.localIdentName = localIdentName;
+        } else {
+            match.loader.options.modules = {
+                localIdentName: localIdentName
+            };
+        }
     }
 
     log("Overrided CSS modules local ident name.");
@@ -57,7 +71,7 @@ function overrideCss(styleConfig, webpackConfig, context) {
         }
 
         if (styleConfig.modules) {
-            const cssModuleLoaders = matches.filter(x => x.loader.options && x.loader.options.modules === true);
+            const cssModuleLoaders = matches.filter(x => x.loader.options && x.loader.options.modules);
 
             cssModuleLoaders.forEach(x => {
                 overrideModuleLoader(x, styleConfig.modules);

--- a/packages/craco/lib/features/webpack/style/css.js
+++ b/packages/craco/lib/features/webpack/style/css.js
@@ -6,24 +6,12 @@ function setModuleLocalIdentName(match, localIdentName) {
     // The css-loader version of create-react-app has changed from 2.1.1 to 3.2.0
     // https://github.com/facebook/create-react-app/commit/f79f30
     if (isBoolean(match.loader.options.modules)) {
-        if (match.loader.options) {
-            delete match.loader.options.getLocalIdent;
-            match.loader.options.localIdentName = localIdentName;
-        } else {
-            match.loader.options = {
-                localIdentName: localIdentName
-            };
-        }
+        delete match.loader.options.getLocalIdent;
+        match.loader.options.localIdentName = localIdentName;
     } else {
         // This setting applies to create-react-app@3.3.0
-        if (match.loader.options) {
-            delete match.loader.options.modules.getLocalIdent;
-            match.loader.options.modules.localIdentName = localIdentName;
-        } else {
-            match.loader.options.modules = {
-                localIdentName: localIdentName
-            };
-        }
+        delete match.loader.options.modules.getLocalIdent;
+        match.loader.options.modules.localIdentName = localIdentName;
     }
 
     log("Overrided CSS modules local ident name.");

--- a/packages/craco/lib/utils.js
+++ b/packages/craco/lib/utils.js
@@ -12,6 +12,10 @@ function isString(value) {
     return typeof value === "string";
 }
 
+function isBoolean(value) {
+    return typeof value === "boolean";
+}
+
 function deepMergeWithArray(...rest) {
     return mergeWith(...rest, (x, y) => {
         if (isArray(x)) {
@@ -24,5 +28,6 @@ module.exports = {
     isFunction,
     isArray,
     isString,
+    isBoolean,
     deepMergeWithArray
 };


### PR DESCRIPTION
In the CRA@3.3.0 deployment, the version of css-loader has been changed to 3.2.0

https://github.com/facebook/create-react-app/commit/f79f30