### PR TITLE
fix: add lodash to dependencies

### DIFF
--- a/packages/craco/lib/args.js
+++ b/packages/craco/lib/args.js
@@ -1,4 +1,4 @@
-const { isNil } = require("lodash");
+const isNil = require("lodash/isNil");
 
 const VERBOSE_ARG = "--verbose";
 const CONFIG_ARG = "--config";

--- a/packages/craco/lib/utils.js
+++ b/packages/craco/lib/utils.js
@@ -1,4 +1,4 @@
-const mergeWith = require("lodash.mergewith");
+const mergeWith = require("lodash/mergeWith");
 
 function isFunction(value) {
     return typeof value === "function";

--- a/packages/craco/package-lock.json
+++ b/packages/craco/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@craco/craco",
-    "version": "5.5.0",
+    "version": "5.6.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -8648,10 +8648,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.11",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-            "dev": true
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "lodash._reinterpolate": {
             "version": "3.0.0",
@@ -8664,11 +8663,6 @@
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
             "dev": true
-        },
-        "lodash.mergewith": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-            "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
         },
         "lodash.sortby": {
             "version": "4.7.0",

--- a/packages/craco/package.json
+++ b/packages/craco/package.json
@@ -40,7 +40,7 @@
     },
     "dependencies": {
         "cross-spawn": "^7.0.0",
-        "lodash.mergewith": "^4.6.2",
+        "lodash": "^4.17.15",
         "webpack-merge": "^4.2.2"
     },
     "version": "5.6.3",


### PR DESCRIPTION
**What's the problem this PR addresses?**

Craco is using `lodash` without declaring it as a dependency

**How did you fix it?**

Added `lodash` to dependencies and since the [modular lodash packages are deprecated](https://lodash.com/per-method-packages) I removed it and imported from `lodash` instead