### PR TITLE
README: Link craco-purescript-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Major changes are available in the [changelog folder](https://github.com/sharega
 * [craco-alias](https://github.com/risenforces/craco-alias) by [@risenforces](https://github.com/risenforces)
 * [craco-favicons](https://github.com/rickysullivan/craco-favicons) by [@rickysullivan](https://github.com/rickysullivan)
 * [craco-styled-jsx](https://github.com/cr4zyc4t/craco-styled-jsx) by [@cr4zyc4t](https://github.com/cr4zyc4t)
+* [craco-purescript-loader](https://github.com/andys8/craco-purescript-loader) by [@andys8](https://github.com/andys8)
 
 ## Acknowledgements
 


### PR DESCRIPTION
I created a plugin to add [purs-loader](https://www.npmjs.com/package/purs-loader) with [`create-react-app`](https://facebook.github.io/create-react-app).

It allows you to use [PureScript](https://www.purescript.org) code.


## Plugin

https://github.com/andys8/craco-purescript-loader