### PR TITLE
Add a warning about API functions

### DIFF
--- a/packages/craco/README.md
+++ b/packages/craco/README.md
@@ -260,6 +260,8 @@ That's what CRACO APIs are for. The current API support Jest and Webpack configs
 
 Accept a `cracoConfig`, a `context` object and `options`. The generated Jest config object is returned.
 
+**Warning:** `createJestConfig` does NOT accept `cracoConfig` as a function. If your `craco.config.js` exposes a config function, you have to call it yourself before passing it to `createJestConfig`.
+
 `createJestConfig(cracoConfig, context = {}, options = { verbose: false, config: null })`
 
 Usage:
@@ -278,6 +280,8 @@ module.exports = jestConfig;
 ### createWebpackDevConfig & createWebpackProdConfig
 
 Accept a `cracoConfig`, a `context` object and `options`. The generated Webpack config object is returned.
+
+**Warning:** Similar to `createJestConfig`, these functions do NOT accept `cracoConfig` as a function. If your `craco.config.js` exposes a config function, you have to call it yourself before passing it further.
 
 `createWebpackDevConfig(cracoConfig, context = {}, options = { verbose: false, config: null })`
 `createWebpackProdConfig(cracoConfig, context = {}, options = { verbose: false, config: null })`

--- a/packages/craco/lib/features/dev-server/api.js
+++ b/packages/craco/lib/features/dev-server/api.js
@@ -1,3 +1,4 @@
+const { isFunction } = require("../../utils");
 const { setArgs } = require("../../args");
 const { createConfigProviderProxy } = require("./create-config-provider-proxy");
 const { processCracoConfig } = require("../../config");
@@ -6,6 +7,9 @@ const { getCraPaths } = require("../../cra");
 function createDevServerConfigProviderProxy(callerCracoConfig, callerContext, options) {
     if (!callerCracoConfig) {
         throw new Error("craco: 'cracoConfig' is required.");
+    }
+    if (isFunction(callerCracoConfig)) {
+        throw new Error("craco: 'cracoConfig' should be an object.");
     }
 
     if (!process.env.NODE_ENV) {

--- a/packages/craco/lib/features/test/api.js
+++ b/packages/craco/lib/features/test/api.js
@@ -1,3 +1,4 @@
+const { isFunction } = require("../../utils");
 const { getCraPaths } = require("../../cra");
 const { mergeJestConfig } = require("./merge-jest-config");
 const { loadJestConfigProvider } = require("../../cra");
@@ -7,6 +8,9 @@ const { processCracoConfig } = require("../../config");
 function createJestConfig(callerCracoConfig, callerContext = {}, options = {}) {
     if (!callerCracoConfig) {
         throw new Error("craco: 'cracoConfig' is required.");
+    }
+    if (isFunction(callerCracoConfig)) {
+        throw new Error("craco: 'cracoConfig' should be an object.");
     }
 
     if (!process.env.NODE_ENV) {

--- a/packages/craco/lib/features/webpack/api.js
+++ b/packages/craco/lib/features/webpack/api.js
@@ -1,3 +1,4 @@
+const { isFunction } = require("../../utils");
 const { mergeWebpackConfig } = require("./merge-webpack-config");
 const { setArgs } = require("../../args");
 const { processCracoConfig } = require("../../config");
@@ -14,6 +15,9 @@ function createWebpackProdConfig(callerCracoConfig, callerContext, options) {
 function createWebpackConfig(callerCracoConfig, callerContext = {}, loadWebpackConfig, env, options = {}) {
     if (!callerCracoConfig) {
         throw new Error("craco: 'cracoConfig' is required.");
+    }
+    if (isFunction(callerCracoConfig)) {
+        throw new Error("craco: 'cracoConfig' should be an object.");
     }
 
     if (!process.env.NODE_ENV) {


### PR DESCRIPTION
Recently I was messing around with `createJestConfig` API function to add some additional config props for the CI environment on a project I'm currently working on. However I've stumbled upon a lot of weird problems when certain props from `craco.config.js` were simply not visible to Jest. After tedious debugging session I've discovered a rather simple reason for that - my `craco.config.js` file exports a config **function**, which apparently is not supported by `createJestConfig` and that fact is neither documented, not reported as an error.

I don't know if this is intentional or not, but I figured that it would be good to at least mention that fact in the API's documentation.