### PR TITLE
Support async configs for scripts (fix #190)

### DIFF
--- a/packages/craco/README.md
+++ b/packages/craco/README.md
@@ -84,6 +84,20 @@ module.exports = function({ env }) {
 }
 ```
 
+or a **promise** or **async function**:
+
+```javascript
+/* craco.config.js */
+
+module.exports = async function({ env }) {
+    await ...
+
+    return {
+        ...
+    };
+}
+```
+
 Update the existing calls to `react-scripts` in the `scripts` section of your `package.json` file to use the `craco` CLI:
 
 ```diff

--- a/packages/craco/lib/config.js
+++ b/packages/craco/lib/config.js
@@ -40,11 +40,11 @@ function processCracoConfig(cracoConfig, context) {
     return applyCracoConfigPlugins(resultingCracoConfig, context);
 }
 
-function loadCracoConfig(context) {
+async function loadCracoConfig(context) {
     log("Found craco config file at: ", configFilePath);
 
     const config = require(configFilePath);
-    const configAsObject = isFunction(config) ? config(context) : config;
+    const configAsObject = await (isFunction(config) ? config(context) : config);
 
     if (!configAsObject) {
         throw new Error("craco: Config function didn't returned a config object.");

--- a/packages/craco/lib/config.js
+++ b/packages/craco/lib/config.js
@@ -64,7 +64,7 @@ function loadCracoConfig(context) {
     return processCracoConfig(configAsObject, context);
 }
 
-// Async configs are supported by the "build", "start", and "test" scripts, but not for APIs like createJestConfig.
+// The "build", "start", and "test" scripts use this to wait for any promises to resolve before they run.
 async function loadCracoConfigAsync(context) {
     const configAsObject = await getConfigAsObject(context);
 

--- a/packages/craco/lib/features/test/create-jest-babel-transform.js
+++ b/packages/craco/lib/features/test/create-jest-babel-transform.js
@@ -9,22 +9,24 @@ function createJestBabelTransform(cracoConfig) {
         configFile: false
     };
 
-    const { addPresets, addPlugins } = cracoConfig.jest.babel;
+    if (cracoConfig) {
+        const { addPresets, addPlugins } = cracoConfig.jest.babel;
 
-    if (cracoConfig.babel) {
-        if (addPresets) {
-            const { presets } = cracoConfig.babel;
+        if (cracoConfig.babel) {
+            if (addPresets) {
+                const { presets } = cracoConfig.babel;
 
-            if (isArray(presets)) {
-                craBabelTransformer.presets = craBabelTransformer.presets.concat(presets);
+                if (isArray(presets)) {
+                    craBabelTransformer.presets = craBabelTransformer.presets.concat(presets);
+                }
             }
-        }
 
-        if (addPlugins) {
-            const { plugins } = cracoConfig.babel;
+            if (addPlugins) {
+                const { plugins } = cracoConfig.babel;
 
-            if (isArray(plugins)) {
-                craBabelTransformer.plugins = plugins;
+                if (isArray(plugins)) {
+                    craBabelTransformer.plugins = plugins;
+                }
             }
         }
     }

--- a/packages/craco/lib/features/test/create-jest-babel-transform.js
+++ b/packages/craco/lib/features/test/create-jest-babel-transform.js
@@ -1,8 +1,8 @@
+const babelJest = require("babel-jest");
+
 const { isArray } = require("../../utils");
 
 function createJestBabelTransform(cracoConfig) {
-    const babelJest = require("babel-jest");
-
     const craBabelTransformer = {
         presets: ["babel-preset-react-app"],
         babelrc: false,

--- a/packages/craco/lib/features/test/create-jest-babel-transform.js
+++ b/packages/craco/lib/features/test/create-jest-babel-transform.js
@@ -1,0 +1,36 @@
+const babelJest = require("babel-jest");
+
+const { isArray } = require("../../utils");
+
+function createJestBabelTransform(cracoConfig) {
+    const craBabelTransformer = {
+        presets: ["babel-preset-react-app"],
+        babelrc: false,
+        configFile: false
+    };
+
+    const { addPresets, addPlugins } = cracoConfig.jest.babel;
+
+    if (cracoConfig.babel) {
+        if (addPresets) {
+            const { presets } = cracoConfig.babel;
+
+            if (isArray(presets)) {
+                craBabelTransformer.presets = craBabelTransformer.presets.concat(presets);
+            }
+        }
+
+        if (addPlugins) {
+            const { plugins } = cracoConfig.babel;
+
+            if (isArray(plugins)) {
+                craBabelTransformer.plugins = plugins;
+            }
+        }
+    }
+    return babelJest.createTransformer(craBabelTransformer);
+}
+
+module.exports = {
+    createJestBabelTransform
+};

--- a/packages/craco/lib/features/test/create-jest-babel-transform.js
+++ b/packages/craco/lib/features/test/create-jest-babel-transform.js
@@ -1,8 +1,8 @@
-const babelJest = require("babel-jest");
-
 const { isArray } = require("../../utils");
 
 function createJestBabelTransform(cracoConfig) {
+    const babelJest = require("babel-jest");
+
     const craBabelTransformer = {
         presets: ["babel-preset-react-app"],
         babelrc: false,

--- a/packages/craco/lib/features/test/jest-babel-transform.js
+++ b/packages/craco/lib/features/test/jest-babel-transform.js
@@ -1,38 +1,6 @@
-const babelJest = require("babel-jest");
-
 const { loadCracoConfig } = require("../../config");
-const { isArray } = require("../../utils");
-
-const craBabelTransformer = {
-    presets: ["babel-preset-react-app"],
-    babelrc: false,
-    configFile: false
-};
-
-const context = {
-    env: process.env.NODE_ENV
-};
+const { createJestBabelTransform } = require("./create-jest-babel-transform");
 
 const cracoConfig = loadCracoConfig(context);
 
-const { addPresets, addPlugins } = cracoConfig.jest.babel;
-
-if (cracoConfig.babel) {
-    if (addPresets) {
-        const { presets } = cracoConfig.babel;
-
-        if (isArray(presets)) {
-            craBabelTransformer.presets = craBabelTransformer.presets.concat(presets);
-        }
-    }
-
-    if (addPlugins) {
-        const { plugins } = cracoConfig.babel;
-
-        if (isArray(plugins)) {
-            craBabelTransformer.plugins = plugins;
-        }
-    }
-}
-
-module.exports = babelJest.createTransformer(craBabelTransformer);
+module.exports = createJestBabelTransform(cracoConfig);

--- a/packages/craco/lib/features/test/jest-babel-transform.js
+++ b/packages/craco/lib/features/test/jest-babel-transform.js
@@ -1,4 +1,3 @@
-const { loadCracoConfig } = require("../../config");
 const { createJestBabelTransform } = require("./create-jest-babel-transform");
 
 let jestBabelTransform;
@@ -10,15 +9,7 @@ module.exports = {
     ...createJestBabelTransform(),
     process(src, filename, config, transformOptions) {
         if (!jestBabelTransform) {
-            let cracoConfig = config.globals && config.globals._cracoConfig;
-            if (!cracoConfig) {
-                const context = {
-                    env: process.env.NODE_ENV
-                };
-                cracoConfig = loadCracoConfig(context);
-            }
-
-            jestBabelTransform = createJestBabelTransform(cracoConfig);
+            jestBabelTransform = createJestBabelTransform(config.globals._cracoConfig);
         }
 
         return jestBabelTransform.process(src, filename, config, transformOptions);

--- a/packages/craco/lib/features/test/jest-babel-transform.js
+++ b/packages/craco/lib/features/test/jest-babel-transform.js
@@ -1,6 +1,26 @@
 const { loadCracoConfig } = require("../../config");
 const { createJestBabelTransform } = require("./create-jest-babel-transform");
 
-const cracoConfig = loadCracoConfig(context);
+let jestBabelTransform;
 
-module.exports = createJestBabelTransform(cracoConfig);
+// cracoConfig is only available inside the transform, but the transform needs to include whatever options cracoConfig
+// specifies. So, the first time this transform is run, it generates a new transform -- using cracoConfig -- and
+// uses that to process files.
+module.exports = {
+    ...createJestBabelTransform(),
+    process(src, filename, config, transformOptions) {
+        if (!jestBabelTransform) {
+            let cracoConfig = config.globals && config.globals._cracoConfig;
+            if (!cracoConfig) {
+                const context = {
+                    env: process.env.NODE_ENV
+                };
+                cracoConfig = loadCracoConfig(context);
+            }
+
+            jestBabelTransform = createJestBabelTransform(cracoConfig);
+        }
+
+        return jestBabelTransform.process(src, filename, config, transformOptions);
+    }
+};

--- a/packages/craco/lib/features/test/merge-jest-config.js
+++ b/packages/craco/lib/features/test/merge-jest-config.js
@@ -5,12 +5,13 @@ const { isFunction, isArray, deepMergeWithArray } = require("../../utils");
 const { log } = require("../../logger");
 const { applyJestConfigPlugins } = require("../plugins");
 const { projectRoot } = require("../../paths");
+const { createJestBabelTransform } = require("./create-jest-babel-transform");
 
 const BABEL_TRANSFORM_ENTRY_KEY_BEFORE_2_1_0 = "^.+\\.(js|jsx)$";
 const BABEL_TRANSFORM_ENTRY_KEY = "^.+\\.(js|jsx|ts|tsx)$";
 
-function overrideBabelTransform(jestConfig, transformKey) {
-    jestConfig.transform[transformKey] = require.resolve("./jest-babel-transform.js");
+function overrideBabelTransform(jestConfig, cracoConfig, transformKey) {
+    jestConfig.transform[transformKey] = createJestBabelTransform(cracoConfig);
 
     log("Overrided Jest Babel transformer.");
 }
@@ -23,18 +24,10 @@ function configureBabel(jestConfig, cracoConfig) {
             const { presets, plugins } = cracoConfig.babel;
 
             if (isArray(presets) || isArray(plugins)) {
-                const { config } = getArgs();
-
-                if (config.isProvided) {
-                    throw new Error(
-                        "craco: Jest + Babel doesn't support --config. Provide a custom location for the craco.config.js file from your package.json file by specifing a value for 'cracoConfig'."
-                    );
-                }
-
                 if (jestConfig.transform[BABEL_TRANSFORM_ENTRY_KEY]) {
-                    overrideBabelTransform(jestConfig, BABEL_TRANSFORM_ENTRY_KEY);
+                    overrideBabelTransform(jestConfig, cracoConfig, BABEL_TRANSFORM_ENTRY_KEY);
                 } else if (jestConfig.transform[BABEL_TRANSFORM_ENTRY_KEY_BEFORE_2_1_0]) {
-                    overrideBabelTransform(jestConfig, BABEL_TRANSFORM_ENTRY_KEY_BEFORE_2_1_0);
+                    overrideBabelTransform(jestConfig, cracoConfig, BABEL_TRANSFORM_ENTRY_KEY_BEFORE_2_1_0);
                 } else {
                     throw new Error(
                         `craco: Cannot find Jest transform entry for Babel ${BABEL_TRANSFORM_ENTRY_KEY} or ${BABEL_TRANSFORM_ENTRY_KEY_BEFORE_2_1_0}.`

--- a/packages/craco/lib/features/test/merge-jest-config.js
+++ b/packages/craco/lib/features/test/merge-jest-config.js
@@ -1,17 +1,20 @@
 const path = require("path");
 
-const { getArgs } = require("../../args");
 const { isFunction, isArray, deepMergeWithArray } = require("../../utils");
 const { log } = require("../../logger");
 const { applyJestConfigPlugins } = require("../plugins");
 const { projectRoot } = require("../../paths");
-const { createJestBabelTransform } = require("./create-jest-babel-transform");
 
 const BABEL_TRANSFORM_ENTRY_KEY_BEFORE_2_1_0 = "^.+\\.(js|jsx)$";
 const BABEL_TRANSFORM_ENTRY_KEY = "^.+\\.(js|jsx|ts|tsx)$";
 
 function overrideBabelTransform(jestConfig, cracoConfig, transformKey) {
-    jestConfig.transform[transformKey] = createJestBabelTransform(cracoConfig);
+    // The cracoConfig needs to be available within the jest-babel-transform in order to honor its settings.
+    // This approach is based on https://github.com/facebook/jest/issues/1468#issuecomment-384825178
+    jestConfig.globals = jestConfig.globals || {};
+    jestConfig.globals._cracoConfig = cracoConfig;
+
+    jestConfig.transform[transformKey] = require.resolve("./jest-babel-transform");
 
     log("Overrided Jest Babel transformer.");
 }

--- a/packages/craco/scripts/build.js
+++ b/packages/craco/scripts/build.js
@@ -7,7 +7,7 @@ findArgsFromCli();
 
 const { log } = require("../lib/logger");
 const { getCraPaths, build } = require("../lib/cra");
-const { loadCracoConfig } = require("../lib/config");
+const { loadCracoConfigAsync } = require("../lib/config");
 const { overrideWebpackProd } = require("../lib/features/webpack/override");
 
 log("Override started with arguments: ", process.argv);
@@ -17,7 +17,7 @@ const context = {
     env: process.env.NODE_ENV
 };
 
-loadCracoConfig(context).then(cracoConfig => {
+loadCracoConfigAsync(context).then(cracoConfig => {
     context.paths = getCraPaths(cracoConfig);
 
     overrideWebpackProd(cracoConfig, context);

--- a/packages/craco/scripts/build.js
+++ b/packages/craco/scripts/build.js
@@ -17,8 +17,9 @@ const context = {
     env: process.env.NODE_ENV
 };
 
-const cracoConfig = loadCracoConfig(context);
-context.paths = getCraPaths(cracoConfig);
+loadCracoConfig(context).then(cracoConfig => {
+    context.paths = getCraPaths(cracoConfig);
 
-overrideWebpackProd(cracoConfig, context);
-build(cracoConfig);
+    overrideWebpackProd(cracoConfig, context);
+    build(cracoConfig);
+});

--- a/packages/craco/scripts/start.js
+++ b/packages/craco/scripts/start.js
@@ -7,7 +7,7 @@ findArgsFromCli();
 
 const { log } = require("../lib/logger");
 const { getCraPaths, start } = require("../lib/cra");
-const { loadCracoConfig } = require("../lib/config");
+const { loadCracoConfigAsync } = require("../lib/config");
 const { overrideWebpackDev } = require("../lib/features/webpack/override");
 const { overrideDevServer } = require("../lib/features/dev-server/override");
 
@@ -18,7 +18,7 @@ const context = {
     env: process.env.NODE_ENV
 };
 
-loadCracoConfig(context).then(cracoConfig => {
+loadCracoConfigAsync(context).then(cracoConfig => {
     context.paths = getCraPaths(cracoConfig);
 
     overrideWebpackDev(cracoConfig, context);

--- a/packages/craco/scripts/start.js
+++ b/packages/craco/scripts/start.js
@@ -18,10 +18,11 @@ const context = {
     env: process.env.NODE_ENV
 };
 
-const cracoConfig = loadCracoConfig(context);
-context.paths = getCraPaths(cracoConfig);
+loadCracoConfig(context).then(cracoConfig => {
+    context.paths = getCraPaths(cracoConfig);
 
-overrideWebpackDev(cracoConfig, context);
-overrideDevServer(cracoConfig, context);
+    overrideWebpackDev(cracoConfig, context);
+    overrideDevServer(cracoConfig, context);
 
-start(cracoConfig);
+    start(cracoConfig);
+});

--- a/packages/craco/scripts/test.js
+++ b/packages/craco/scripts/test.js
@@ -17,8 +17,9 @@ const context = {
     env: process.env.NODE_ENV
 };
 
-const cracoConfig = loadCracoConfig(context);
-context.paths = getCraPaths(cracoConfig);
+loadCracoConfig(context).then(cracoConfig => {
+    context.paths = getCraPaths(cracoConfig);
 
-overrideJest(cracoConfig, context);
-test(cracoConfig);
+    overrideJest(cracoConfig, context);
+    test(cracoConfig);
+});

--- a/packages/craco/scripts/test.js
+++ b/packages/craco/scripts/test.js
@@ -8,7 +8,7 @@ findArgsFromCli();
 const { log } = require("../lib/logger");
 const { getCraPaths, test } = require("../lib/cra");
 const { overrideJest } = require("../lib/features/test/override");
-const { loadCracoConfig } = require("../lib/config");
+const { loadCracoConfigAsync } = require("../lib/config");
 
 log("Override started with arguments: ", process.argv);
 log("For environment: ", process.env.NODE_ENV);
@@ -17,7 +17,7 @@ const context = {
     env: process.env.NODE_ENV
 };
 
-loadCracoConfig(context).then(cracoConfig => {
+loadCracoConfigAsync(context).then(cracoConfig => {
     context.paths = getCraPaths(cracoConfig);
 
     overrideJest(cracoConfig, context);


### PR DESCRIPTION
This is intended to address issue #190, and it uses the same approach as was written there.

I added a second option for loading the craco config: `loadCracoConfigAsync`, which is exactly like `loadCracoConfig` except it returns a promise. `loadCracoConfig` is unchanged, so it still works the same for the APIs that use it.

With that addition, the built-in scripts (build, start, test) can support `craco.config.js` files which return a promise or an async function, while API calls like `createJestConfig` work exactly like before (i.e. the caller has to resolve the config as an object.)

This seemed similar to the "config might be a function" discussion in PR #195, so I tried to match that by adding validation that checks for promises.