### PR TITLE
Fix jest / babel config merging for CRA v4

### DIFF
--- a/packages/craco/lib/features/jest/merge-jest-config.js
+++ b/packages/craco/lib/features/jest/merge-jest-config.js
@@ -6,7 +6,8 @@ const { applyJestConfigPlugins } = require("../plugins");
 const { projectRoot } = require("../../paths");
 
 const BABEL_TRANSFORM_ENTRY_KEY_BEFORE_2_1_0 = "^.+\\.(js|jsx)$";
-const BABEL_TRANSFORM_ENTRY_KEY = "^.+\\.(js|jsx|ts|tsx)$";
+const BABEL_TRANSFORM_ENTRY_KEY_BEFORE_4_0_0 = "^.+\\.(js|jsx|ts|tsx)$";
+const BABEL_TRANSFORM_ENTRY_KEY = "^.+\\.(js|jsx|mjs|cjs|ts|tsx)$";
 
 function overrideBabelTransform(jestConfig, cracoConfig, transformKey) {
     // The cracoConfig needs to be available within the jest-babel-transform in order to honor its settings.
@@ -29,11 +30,13 @@ function configureBabel(jestConfig, cracoConfig) {
             if (isArray(presets) || isArray(plugins)) {
                 if (jestConfig.transform[BABEL_TRANSFORM_ENTRY_KEY]) {
                     overrideBabelTransform(jestConfig, cracoConfig, BABEL_TRANSFORM_ENTRY_KEY);
+                } else if (jestConfig.transform[BABEL_TRANSFORM_ENTRY_KEY_BEFORE_4_0_0]) {
+                    overrideBabelTransform(jestConfig, cracoConfig, BABEL_TRANSFORM_ENTRY_KEY_BEFORE_4_0_0);
                 } else if (jestConfig.transform[BABEL_TRANSFORM_ENTRY_KEY_BEFORE_2_1_0]) {
                     overrideBabelTransform(jestConfig, cracoConfig, BABEL_TRANSFORM_ENTRY_KEY_BEFORE_2_1_0);
                 } else {
                     throw new Error(
-                        `craco: Cannot find Jest transform entry for Babel ${BABEL_TRANSFORM_ENTRY_KEY} or ${BABEL_TRANSFORM_ENTRY_KEY_BEFORE_2_1_0}.`
+                        `craco: Cannot find Jest transform entry for Babel ${BABEL_TRANSFORM_ENTRY_KEY}, ${BABEL_TRANSFORM_ENTRY_KEY_BEFORE_4_0_0} or ${BABEL_TRANSFORM_ENTRY_KEY_BEFORE_2_1_0}.`
                     );
                 }
             }


### PR DESCRIPTION
As mentioned in #205 (or more specifically [this comment](https://github.com/gsoft-inc/craco/issues/205#issuecomment-716622339)) jest breaks with CRA v4.

The regex key, that determines if a file should be transformed with babel, changed. This causes craco to not be able to merge the custom babel config into the jest config.

The new key is `"^.+\.(js|jsx|mjs|cjs|ts|tsx)$"`.

For backwards compatibility I used the same naming schema / method as for the 2.1.0 change before (this should probably be removed, as 2.1.0 isn't supported anymore anyways).