### PR TITLE
Replace deprected autoFix setting with new option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,9 @@
     "javascript.validate.enable": true,
     "json.format.enable": false,
     // Required to allow auto format on save with Prettier + ESLint + Vetur.
-    "eslint.autoFixOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
     "eslint.alwaysShowStatus": true,
     "sort-imports.suppress-warnings": true,
     "search.exclude": {


### PR DESCRIPTION
This migrates the deprecated option to the recommended replacement.

For more details see the [changelog](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint#release-notes) of the eslint plugin.