### PR TITLE
Add recipe for loading markdown

### DIFF
--- a/recipes/use-markdown-loader/craco.config.js
+++ b/recipes/use-markdown-loader/craco.config.js
@@ -1,0 +1,34 @@
+// Import Markdown files as HTML into your React Application
+// <https://github.com/peerigon/markdown-loader>
+
+const { addBeforeLoader, loaderByName } = require('@craco/craco');
+
+// Additional configuration for Typescript users: add `declare module '*.md'` to your `index.d.ts` file.
+
+module.exports = {
+  webpack: {
+    configure: (webpackConfig) => {
+      webpackConfig.resolve.extensions.push('.md');
+
+      const markdownLoader = {
+        test: /\.md$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: require.resolve('html-loader'),
+          },
+          {
+            loader: require.resolve('markdown-loader'),
+            options: {
+              // see <https://marked.js.org/using_advanced#options>
+            },
+          },
+        ],
+      };
+
+      addBeforeLoader(webpackConfig, loaderByName('file-loader'), markdownLoader);
+
+      return webpackConfig;
+    },
+  },
+};


### PR DESCRIPTION
This pull request adds a recipe for how to use craco to support loading of markdown into your React application which enables code similar to the following:

```js
import myMarkdownAsHtml from './myMarkdown.md';

const MyComponent = () => <div dangerouslySetInnerHTML={{ __html: myMarkdownAsHtml }} />;
```

Note that Typescript users should additionally include the following in their `index.d.ts` file:

```ts
declare module '*.md';
```