### PR TITLE
Support jsx-runtime for jest babel transform

### DIFF
--- a/packages/craco/lib/features/jest/create-jest-babel-transform.js
+++ b/packages/craco/lib/features/jest/create-jest-babel-transform.js
@@ -1,10 +1,33 @@
 const babelJest = require("babel-jest");
 
 const { isArray } = require("../../utils");
+/**
+ * To check if support jsx-runtime
+ * Copy from https://github.com/facebook/create-react-app/blob/2b1161b34641bb4d2f269661cd636bbcd4888406/packages/react-scripts/config/jest/babelTransform.js#L12
+ */
+const hasJsxRuntime = (() => {
+    if (process.env.DISABLE_NEW_JSX_TRANSFORM === "true") {
+        return false;
+    }
+
+    try {
+        require.resolve("react/jsx-runtime");
+        return true;
+    } catch (e) {
+        return false;
+    }
+})();
 
 function createJestBabelTransform(cracoConfig) {
     const craBabelTransformer = {
-        presets: ["babel-preset-react-app"],
+        presets: [
+            [
+                "babel-preset-react-app",
+                {
+                    runtime: hasJsxRuntime ? "automatic" : "classic"
+                }
+            ]
+        ],
         babelrc: false,
         configFile: false
     };


### PR DESCRIPTION
This is a part of work about #205 .
I upgrade react-scripts to 4.0.1 version, and everything fine with `npm run start / npm run build`.
But when I run `npm run test`, the error occurs like this:

![image](https://user-images.githubusercontent.com/4034161/100111889-93dcbd80-2ea9-11eb-8c55-d420daade75f.png)

Here is the example project: [craco-jsx-runtime-jest-bug](https://github.com/wanglam/craco-jsx-runtime-jest-bug), will get the same error.

Then I go to the [react-scripts/config/jest/babelTransform.js](https://github.com/facebook/create-react-app/blob/2b1161b34641bb4d2f269661cd636bbcd4888406/packages/react-scripts/config/jest/babelTransform.js), find we need runtime option to support `jsx-runtime`. So I create this pull request.

For old version babel-preset-react-app(I have checked [this file](https://github.com/facebook/create-react-app/blob/1407287839f94151cec729bd89441d4eee7d9dd3/packages/babel-preset-react-app/create.js)), it's ok to pass same options, I just ignore version check.