### PR TITLE
Add support for .cracorc and .cracorc.js

### DIFF
--- a/packages/craco/README.md
+++ b/packages/craco/README.md
@@ -98,7 +98,13 @@ $ npm run build
 
 ## Configuration
 
-CRACO is configured with the `craco.config.js` file. This file is divided into sections representing the major parts of what makes up the default create react app. 
+CRACO is configured with a `craco.config.js`, `.cracorc.js` or `.cracorc` file. This file is divided into sections representing the major parts of what makes up the default create react app. 
+
+If there are multiple configuration files in the same directory, CRACO will only use one. The priority order is:
+
+1. `craco.config.js`
+2. `.cracorc.js`
+3. `.cracorc`
 
 ### Configuration File 
 

--- a/packages/craco/lib/paths.js
+++ b/packages/craco/lib/paths.js
@@ -31,7 +31,7 @@ if (args.config.isProvided) {
             const filePath = path.join(projectRoot, filename);
 
             if (fs.existsSync(filePath)) {
-                configFilePath = path.resolve(filePath);
+                configFilePath = filePath;
                 break;
             }
         }

--- a/packages/craco/lib/paths.js
+++ b/packages/craco/lib/paths.js
@@ -11,6 +11,8 @@ log("Project root path resolved to: ", projectRoot);
 
 let configFilePath = "";
 
+const configFilenames = ["craco.config.js", ".cracorc.js", ".cracorc"];
+
 const args = getArgs();
 
 if (args.config.isProvided) {
@@ -25,7 +27,14 @@ if (args.config.isProvided) {
 
         configFilePath = path.resolve(projectRoot, package.cracoConfig);
     } else {
-        configFilePath = path.resolve(projectRoot, "craco.config.js");
+        for (const filename of configFilenames) {
+            const filePath = path.join(projectRoot, filename);
+
+            if (fs.existsSync(filePath)) {
+                configFilePath = path.resolve(filePath);
+                break;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
PR for https://github.com/gsoft-inc/craco/issues/213

This PR contains : 
- The craco configuration can now be loaded from rc files.
   The priority order is:
      1. `craco.config.js`
      2. `.cracorc.js`
      3. `.cracorc`
- Updated the documentation to reflect those changes