### PR TITLE
Exported Plugin utility functions and the craco config to remove a webpack plugin  Issue#159

### DIFF
--- a/packages/craco/README.md
+++ b/packages/craco/README.md
@@ -920,7 +920,7 @@ Add new *plugins* to the webpack config.
 Usage:
 
 ```javascript
-const { addPlugins, loaderByName } = require("@craco/craco");
+const { addPlugins } = require("@craco/craco");
 
 const myNewWebpackPlugin = require.resolve("ESLintWebpackPlugin");
 

--- a/packages/craco/README.md
+++ b/packages/craco/README.md
@@ -167,7 +167,6 @@ module.exports = {
         plugins: {
             add: [], 
             remove: [],
-            remove: (plugins, { env, paths }) => { return plugins; }
         },
         configure: { /* Any webpack configuration options: https://webpack.js.org/configuration */ },
         configure: (webpackConfig, { env, paths }) => { return webpackConfig; }

--- a/packages/craco/README.md
+++ b/packages/craco/README.md
@@ -165,6 +165,10 @@ module.exports = {
     webpack: {
         alias: {},
         plugins: [],
+        removePlugins: {
+		    pluginNames: [],
+        }
+        removePlugins: (plugins, { env, paths }) => { return plugins; };
         configure: { /* Any webpack configuration options: https://webpack.js.org/configuration */ },
         configure: (webpackConfig, { env, paths }) => { return webpackConfig; }
     },

--- a/packages/craco/README.md
+++ b/packages/craco/README.md
@@ -164,11 +164,11 @@ module.exports = {
     },
     webpack: {
         alias: {},
-        plugins: [],
-        removePlugins: {
-		    pluginNames: [],
-        }
-        removePlugins: (plugins, { env, paths }) => { return plugins; };
+        plugins: {
+            add: [], 
+            remove: [],
+            remove: (plugins, { env, paths }) => { return plugins; }
+        },
         configure: { /* Any webpack configuration options: https://webpack.js.org/configuration */ },
         configure: (webpackConfig, { env, paths }) => { return webpackConfig; }
     },

--- a/packages/craco/README.md
+++ b/packages/craco/README.md
@@ -677,10 +677,13 @@ A few utility functions are provided by CRACO to help you develop a plugin:
  - `addBeforeLoaders`
  - `addAfterLoader`
  - `addAfterLoaders`
+ - `getPlugin`
+ - `removePlugins`
+ - `addPlugins`
  - `throwUnexpectedConfigError`
  
 ```javascript
-const { getLoader, getLoaders, removeLoader, loaderByName, throwUnexpectedConfigError } = require("@craco/craco");
+const { getLoader, getLoaders, removeLoader, loaderByName, getPlugin, removePlugins, addPlugins, pluginByName, throwUnexpectedConfigError } = require("@craco/craco");
 ```
 
 #### getLoader
@@ -863,6 +866,67 @@ const myNewWebpackLoader = {
 
 addAfterLoaders(webpackConfig, loaderByName("eslint-loader"), myNewWebpackLoader);
 ```
+
+#### getPlugin
+
+Retrieve the **first** plugin that match the specified criteria from the webpack config.
+
+Returns:
+
+```javascript
+{
+    isFound: true | false,
+    match: {...} // the webpack plugin
+}
+```
+
+Usage:
+
+```javascript
+const { getPlugin, pluginByName } = require("@craco/craco");
+
+const { isFound, match } = getPlugin(webpackConfig, pluginByName("ESLintWebpackPlugin"));
+
+if (isFound) {
+    // do stuff...
+}
+```
+
+#### removePlugins
+
+Remove **all** the plugins that match the specified criteria from the webpack config.
+
+Returns:
+
+```javascript
+{
+    hasRemovedAny:: true | false,
+    removedCount:: int
+}
+```
+
+Usage:
+
+```javascript
+const { removePlugins, pluginByName } = require("@craco/craco");
+
+removePlugins(webpackConfig, pluginByName("ESLintWebpackPlugin"));
+```
+
+#### addPlugins
+
+Add new *plugins* to the webpack config.
+
+Usage:
+
+```javascript
+const { addPlugins, loaderByName } = require("@craco/craco");
+
+const myNewWebpackPlugin = require.resolve("ESLintWebpackPlugin");
+
+addPlugins(webpackConfig, [myNewWebpackPlugin]);
+```
+
 
 #### throwUnexpectedConfigError
 

--- a/packages/craco/index.js
+++ b/packages/craco/index.js
@@ -8,6 +8,7 @@ const {
     addAfterLoaders,
     loaderByName
 } = require("./lib/loaders");
+const { getPlugin, pluginByName, addPlugins, removePlugins } = require("./lib/webpack-plugins");
 const { when, whenDev, whenProd, whenTest } = require("./lib/user-config-utils");
 const { throwUnexpectedConfigError, gitHubIssueUrl } = require("./lib/plugin-utils");
 const { ESLINT_MODES } = require("./lib/features/webpack/eslint");
@@ -25,6 +26,10 @@ module.exports = {
     addAfterLoader,
     addAfterLoaders,
     loaderByName,
+    getPlugin,
+    pluginByName,
+    addPlugins,
+    removePlugins,
     when,
     whenDev,
     whenProd,

--- a/packages/craco/lib/features/webpack/merge-webpack-config.js
+++ b/packages/craco/lib/features/webpack/merge-webpack-config.js
@@ -7,7 +7,11 @@ const { overrideEsLint } = require("./eslint");
 const { overrideStyle } = require("./style/style");
 const { overrideTypeScript } = require("./typescript");
 const { applyWebpackConfigPlugins } = require("../plugins");
-const { addPlugins: addWebpackPlugins } = require("../../webpack-plugins");
+const {
+    addPlugins: addWebpackPlugins,
+    removePlugins: removeWebpackPlugins,
+    pluginByName
+} = require("../../webpack-plugins");
 
 function addAlias(webpackConfig, webpackAlias) {
     // TODO: ensure is a plain object, if not, log an error.
@@ -24,7 +28,7 @@ function addPlugins(webpackConfig, webpackPlugins) {
     }
 }
 
-function removeWebpackPlugins(webpackConfig, removePlugins, context) {
+function removePluginsFromWebpackConfig(webpackConfig, removePlugins, context) {
     if (!removePlugins) {
         return;
     }
@@ -37,7 +41,7 @@ function removeWebpackPlugins(webpackConfig, removePlugins, context) {
         // TODO: ensure is otherwise a plain object, if not, log an error.
         if (removePlugins.pluginNames && isArray(removePlugins.pluginNames)) {
             for (const pluginName of removePlugins.pluginNames) {
-                removeWebpackPlugins(webpackConfig, pluginName);
+                removeWebpackPlugins(webpackConfig, pluginByName(pluginName));
                 log(`Removed webpack plugin ${pluginName}.`);
             }
 
@@ -82,8 +86,11 @@ function mergeWebpackConfig(cracoConfig, webpackConfig, context) {
             addAlias(resultingWebpackConfig, alias);
         }
 
+        if (removePlugins) {
+            removePluginsFromWebpackConfig(resultingWebpackConfig, removePlugins, context);
+        }
+
         if (plugins) {
-            removeWebpackPlugins(resultingWebpackConfig, removePlugins, context);
             addPlugins(resultingWebpackConfig, plugins);
         }
 

--- a/packages/craco/lib/features/webpack/merge-webpack-config.js
+++ b/packages/craco/lib/features/webpack/merge-webpack-config.js
@@ -37,8 +37,13 @@ function removePluginsFromWebpackConfig(webpackConfig, remove) {
 
     if (isArray(remove)) {
         for (const pluginName of remove) {
-            removeWebpackPlugins(webpackConfig, pluginByName(pluginName));
-            log(`Removed webpack plugin ${pluginName}.`);
+            const { hasRemovedAny } = removeWebpackPlugins(webpackConfig, pluginByName(pluginName));
+
+            if (hasRemovedAny) {
+                log(`Removed webpack plugin ${pluginName}.`);
+            } else {
+                log(`Did not remove webpack plugin ${pluginName}.`);
+            }
         }
 
         log("Removed webpack plugins.");

--- a/packages/craco/lib/features/webpack/merge-webpack-config.js
+++ b/packages/craco/lib/features/webpack/merge-webpack-config.js
@@ -25,32 +25,25 @@ function addPlugins(webpackConfig, webpackPlugins) {
         addWebpackPlugins(webpackConfig, webpackPlugins);
 
         log("Added webpack plugins.");
+    } else {
+        throw new Error(`craco: 'webpack.plugins.add' needs to be a an array of plugins`);
     }
 }
 
-function removePluginsFromWebpackConfig(webpackConfig, remove, context) {
+function removePluginsFromWebpackConfig(webpackConfig, remove) {
     if (!remove) {
         return;
     }
 
-    if (isFunction(remove)) {
-        webpackConfig.plugins = remove(webpackConfig.plugins, context);
+    if (isArray(remove)) {
+        for (const pluginName of remove) {
+            removeWebpackPlugins(webpackConfig, pluginByName(pluginName));
+            log(`Removed webpack plugin ${pluginName}.`);
+        }
 
         log("Removed webpack plugins.");
     } else {
-        // TODO: ensure is otherwise a plain object, if not, log an error.
-        if (isArray(remove)) {
-            for (const pluginName of remove) {
-                removeWebpackPlugins(webpackConfig, pluginByName(pluginName));
-                log(`Removed webpack plugin ${pluginName}.`);
-            }
-
-            log("Removed webpack plugins.");
-        } else {
-            throw new Error(
-                `craco: 'webpack.removePlugins' needs to be a function or an object containing an array named pluginNames`
-            );
-        }
+        throw new Error(`craco: 'webpack.plugins.remove' needs to be a an array of plugin names`);
     }
 }
 
@@ -97,7 +90,7 @@ function mergeWebpackConfig(cracoConfig, webpackConfig, context) {
                 }
 
                 if (remove) {
-                    removePluginsFromWebpackConfig(resultingWebpackConfig, remove, context);
+                    removePluginsFromWebpackConfig(resultingWebpackConfig, remove);
                 }
             }
         }

--- a/packages/craco/lib/webpack-plugins.js
+++ b/packages/craco/lib/webpack-plugins.js
@@ -13,6 +13,12 @@ function getPlugin(webpackConfig, matcher) {
     };
 }
 
+function addPlugins(webpackConfig, webpackPlugins) {
+    webpackConfig.plugins = webpackPlugins.concat(webpackConfig.plugins || []);
+
+    return webpackConfig;
+}
+
 function removePlugins(webpackConfig, matcher) {
     const prevCount = webpackConfig.plugins.length;
     webpackConfig.plugins = webpackConfig.plugins.filter(x => !matcher(x));
@@ -27,5 +33,6 @@ function removePlugins(webpackConfig, matcher) {
 module.exports = {
     getPlugin,
     pluginByName,
+    addPlugins,
     removePlugins
 };

--- a/packages/craco/lib/webpack-plugins.js
+++ b/packages/craco/lib/webpack-plugins.js
@@ -15,8 +15,6 @@ function getPlugin(webpackConfig, matcher) {
 
 function addPlugins(webpackConfig, webpackPlugins) {
     webpackConfig.plugins = webpackPlugins.concat(webpackConfig.plugins || []);
-
-    return webpackConfig;
 }
 
 function removePlugins(webpackConfig, matcher) {

--- a/recipes/add-stylelint/craco.config.js
+++ b/recipes/add-stylelint/craco.config.js
@@ -4,12 +4,14 @@ const StyleLintPlugin = require("stylelint-webpack-plugin");
 
 module.exports = {
     webpack: {
-        plugins: [
-            new StyleLintPlugin({
-                configBasedir: __dirname,
-                context: path.resolve(__dirname, "src"),
-                files: ["**/*.css"]
-            })
-        ]
+        plugins: {
+            add: [
+                new StyleLintPlugin({
+                    configBasedir: __dirname,
+                    context: path.resolve(__dirname, "src"),
+                    files: ["**/*.css"]
+                })
+            ]
+        }
     }
 };


### PR DESCRIPTION
This PR adds the following code :
- Craco now exports the new plugin utility functions created in [this PR](https://github.com/gsoft-inc/craco/pull/219).
- Added documentation for those utility functions.
- Added a way in the craco config to exclude some plugins from webpack. Details in [this issue](https://github.com/gsoft-inc/craco/issues/159)

