### PR TITLE
Fix removal of webpack plugins

### DIFF
--- a/packages/craco/lib/features/webpack/merge-webpack-config.js
+++ b/packages/craco/lib/features/webpack/merge-webpack-config.js
@@ -113,5 +113,5 @@ function mergeWebpackConfig(cracoConfig, webpackConfig, context) {
 }
 
 module.exports = {
-    mergeWebpackConfig,
+    mergeWebpackConfig
 };

--- a/packages/craco/lib/features/webpack/merge-webpack-config.js
+++ b/packages/craco/lib/features/webpack/merge-webpack-config.js
@@ -10,7 +10,7 @@ const { applyWebpackConfigPlugins } = require("../plugins");
 const {
     addPlugins: addWebpackPlugins,
     removePlugins: removeWebpackPlugins,
-    pluginByName
+    pluginByName,
 } = require("../../webpack-plugins");
 
 function addAlias(webpackConfig, webpackAlias) {
@@ -90,12 +90,14 @@ function mergeWebpackConfig(cracoConfig, webpackConfig, context) {
                 addPlugins(resultingWebpackConfig, plugins);
             } else {
                 const { add, remove } = plugins;
-                if (add) {
-                    addPlugins(resultingWebpackConfig, add);
-                }
 
                 if (remove) {
                     removePluginsFromWebpackConfig(resultingWebpackConfig, remove);
+                }
+
+                // Add after removing to preserve any plugins explicitely added via the Craco config
+                if (add) {
+                    addPlugins(resultingWebpackConfig, add);
                 }
             }
         }
@@ -111,5 +113,5 @@ function mergeWebpackConfig(cracoConfig, webpackConfig, context) {
 }
 
 module.exports = {
-    mergeWebpackConfig
+    mergeWebpackConfig,
 };

--- a/packages/craco/lib/features/webpack/merge-webpack-config.js
+++ b/packages/craco/lib/features/webpack/merge-webpack-config.js
@@ -10,7 +10,7 @@ const { applyWebpackConfigPlugins } = require("../plugins");
 const {
     addPlugins: addWebpackPlugins,
     removePlugins: removeWebpackPlugins,
-    pluginByName,
+    pluginByName
 } = require("../../webpack-plugins");
 
 function addAlias(webpackConfig, webpackAlias) {


### PR DESCRIPTION
If the same plugin appears in the Webpack `remove` and `add` arrays, it adds it first then removes it. This makes it impossible to remove a default CRA Webpack plugin and replace it with a new instance of the same plugin, as described in https://github.com/gsoft-inc/craco/issues/244.