### PR TITLE
Added an exception to show missing config file

### DIFF
--- a/packages/craco/lib/config.js
+++ b/packages/craco/lib/config.js
@@ -41,6 +41,10 @@ function processCracoConfig(cracoConfig, context) {
 }
 
 function getConfigAsObject(context) {
+    if (configFilePath == undefined || configFilePath.length == 0) {
+        throw new Error("craco: Config file not found. check if file exists at root (craco.config.js, .cracorc.js, .cracorc)");
+    }
+    
     log("Found craco config file at: ", configFilePath);
 
     const config = require(configFilePath);


### PR DESCRIPTION
I was trying out the package when I ran into an error where it said id must not be null. this was actually caused by an invalid name of the config file though I figured it out easily It would have been better if there was a proper error for this situation. 

Added an Error to show that the config file was not found.