### PR TITLE
Fix: pass context to eslint pluginOptions

### DIFF
--- a/packages/craco/lib/features/webpack/eslint.js
+++ b/packages/craco/lib/features/webpack/eslint.js
@@ -113,7 +113,7 @@ function overrideEsLint(cracoConfig, webpackConfig, context) {
         }
 
         if (pluginOptions) {
-            applyPluginOptions(match, pluginOptions);
+            applyPluginOptions(match, pluginOptions, context);
         }
     }
 


### PR DESCRIPTION
As the documentation states the second parameter of `eslint.pluginOptions` should be `context` but was not being passed correctly.