### PR TITLE
Add support for prepending or appending Webpack plugins

### DIFF
--- a/packages/craco/README.md
+++ b/packages/craco/README.md
@@ -166,8 +166,13 @@ module.exports = {
     webpack: {
         alias: {},
         plugins: {
-            add: [], /* An array of plugins */ 
-            remove: [],  /* An array of plugin constructor's names (i.e. "StyleLintPlugin", "ESLintWebpackPlugin" ) */ 
+            add: [], /* An array of plugins */
+            add: [
+                plugin1,
+                [plugin2, "append"],
+                [plugin3, "prepend"], /* Specify if plugin should be appended or prepended */
+            ], /* An array of plugins */
+            remove: [],  /* An array of plugin constructor's names (i.e. "StyleLintPlugin", "ESLintWebpackPlugin" ) */
         },
         configure: { /* Any webpack configuration options: https://webpack.js.org/configuration */ },
         configure: (webpackConfig, { env, paths }) => { return webpackConfig; }
@@ -925,6 +930,8 @@ const { addPlugins } = require("@craco/craco");
 const myNewWebpackPlugin = require.resolve("ESLintWebpackPlugin");
 
 addPlugins(webpackConfig, [myNewWebpackPlugin]);
+addPlugins(webpackConfig, [ [myNewWebpackPlugin, "append"] ]);
+addPlugins(webpackConfig, [ [myNewWebpackPlugin, "prepend"] ]);
 ```
 
 

--- a/packages/craco/lib/webpack-plugins.js
+++ b/packages/craco/lib/webpack-plugins.js
@@ -14,7 +14,24 @@ function getPlugin(webpackConfig, matcher) {
 }
 
 function addPlugins(webpackConfig, webpackPlugins) {
-    webpackConfig.plugins = webpackPlugins.concat(webpackConfig.plugins || []);
+    const prependPlugins = [];
+    const appendPlugins = [];
+
+    for (const webpackPlugin of webpackPlugins) {
+        if (Array.isArray(webpackPlugin)) {
+            const [plugin, order] = webpackPlugin;
+            if (order === "append") {
+                appendPlugins.push(plugin);
+            } else {
+                // Existing behaviour is to prepend
+                prependPlugins.push(plugin);
+            }
+            continue;
+        }
+        prependPlugins.push(webpackPlugin);
+    }
+
+    webpackConfig.plugins = [...prependPlugins, ...webpackConfig.plugins, ...appendPlugins];
 }
 
 function removePlugins(webpackConfig, matcher) {

--- a/packages/craco/tests/webpack-plugins.test.js
+++ b/packages/craco/tests/webpack-plugins.test.js
@@ -1,0 +1,67 @@
+const { addPlugins } = require("../lib/webpack-plugins");
+
+describe("webpack-plugins", () => {
+    describe("addPlugins", () => {
+        test("preserves legacy behaviour", () => {
+            // Legacy behaviour prepends any plugins into the config.
+            const webpackCfg = {
+                plugins: ["test 1"]
+            };
+
+            addPlugins(webpackCfg, ["test 2"]);
+
+            expect(webpackCfg.plugins).toHaveLength(2);
+            expect(webpackCfg.plugins[0]).toStrictEqual("test 2");
+            expect(webpackCfg.plugins[1]).toStrictEqual("test 1");
+        });
+
+        test("defaults to legacy behaviour if invalid operation provided", () => {
+            const webpackCfg = {
+                plugins: ["test 1"]
+            };
+
+            addPlugins(webpackCfg, [["test 2", "cake"]]);
+
+            expect(webpackCfg.plugins).toHaveLength(2);
+            expect(webpackCfg.plugins[0]).toStrictEqual("test 2");
+            expect(webpackCfg.plugins[1]).toStrictEqual("test 1");
+        });
+
+        test("prepends to the plugin list", () => {
+            const webpackCfg = {
+                plugins: ["test 1"]
+            };
+
+            addPlugins(webpackCfg, [["test 2", "prepend"]]);
+
+            expect(webpackCfg.plugins).toHaveLength(2);
+            expect(webpackCfg.plugins[0]).toStrictEqual("test 2");
+            expect(webpackCfg.plugins[1]).toStrictEqual("test 1");
+        });
+
+        test("appends to the plugin list", () => {
+            const webpackCfg = {
+                plugins: ["test 1"]
+            };
+
+            addPlugins(webpackCfg, [["test 2", "append"]]);
+
+            expect(webpackCfg.plugins).toHaveLength(2);
+            expect(webpackCfg.plugins[0]).toStrictEqual("test 1");
+            expect(webpackCfg.plugins[1]).toStrictEqual("test 2");
+        });
+
+        test("prepends and appends to the plugin list", () => {
+            const webpackCfg = {
+                plugins: ["test 1"]
+            };
+
+            addPlugins(webpackCfg, [["test 2", "append"], ["test 3", "prepend"]]);
+
+            expect(webpackCfg.plugins).toHaveLength(3);
+            expect(webpackCfg.plugins[0]).toStrictEqual("test 3");
+            expect(webpackCfg.plugins[1]).toStrictEqual("test 1");
+            expect(webpackCfg.plugins[2]).toStrictEqual("test 2");
+        });
+    });
+});


### PR DESCRIPTION
I was having issues when converting from `react-app-rewired` to `craco` due to previously our changes / additions to the Webpack config would append plugins, but adding plugins in `craco` always prepends them.

This caused an issue where `HTMLWebpackPlugin` would not work as expected due to the ordering, and in [webpack the plugin order does matter](https://stackoverflow.com/questions/41470771/webpack-does-the-order-of-plugins-matter)

This introduces an API change while preserving the existing behaviour too if desired (and by default).

The change allows you to pass in an array containing a plugin and a string to specify `prepend` or `append`.

Updated the docs I could see, and added tests to test the changes with the legacy behaviour.

Happy to hear any thoughts or make any changes.