### PR TITLE
add config 'craco.config.cjs' to support for ES6 module

### DIFF
--- a/packages/craco/lib/config.js
+++ b/packages/craco/lib/config.js
@@ -35,6 +35,7 @@ const explorer = cosmiconfigSync(moduleName, {
         "package.json",
         `${moduleName}.config.ts`,
         `${moduleName}.config.js`,
+        `${moduleName}.config.cjs`,
         `.${moduleName}rc.ts`,
         `.${moduleName}rc.js`,
         `.${moduleName}rc`


### PR DESCRIPTION
When the react project is using ES6 module(using type="module" in package.json), we need to craco to support config file `craro.config.cjs`.