### PR TITLE
fix: load ts config file synchronously

### DIFF
--- a/packages/craco/lib/config.js
+++ b/packages/craco/lib/config.js
@@ -1,5 +1,5 @@
 const { cosmiconfigSync } = require("cosmiconfig");
-const { default: tsLoader } = require("@endemolshinegroup/cosmiconfig-typescript-loader");
+const { get } = require("lodash");
 
 const path = require("path");
 
@@ -41,7 +41,12 @@ const explorer = cosmiconfigSync(moduleName, {
         `.${moduleName}rc`
     ],
     loaders: {
-        ".ts": tsLoader
+        ".ts": filePath => {
+            require("ts-node/register");
+            const result = require(filePath);
+
+            return get(result, "default", result);
+        }
     }
 });
 

--- a/packages/craco/package.json
+++ b/packages/craco/package.json
@@ -39,7 +39,6 @@
         "react-scripts": "4.*"
     },
     "dependencies": {
-        "@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
         "cosmiconfig": "^7.0.1",
         "cross-spawn": "^7.0.0",
         "lodash": "^4.17.15",


### PR DESCRIPTION
This PR makes config loading from a TS file synchronous.

Fix #290 