### PR TITLE
fix: babel-jest createTransformer issue

### DIFF
--- a/packages/craco/lib/features/jest/create-jest-babel-transform.js
+++ b/packages/craco/lib/features/jest/create-jest-babel-transform.js
@@ -1,4 +1,5 @@
-const babelJest = require("babel-jest");
+const babelJestMd = require('babel-jest');
+const babelJest = babelJestMd.__esModule ? babelJestMd.default : babelJestMd;
 
 const { isArray } = require("../../utils");
 /**


### PR DESCRIPTION
`create-react-app v5` uses `babel-jest v27`. The way of exporting `babel-jest` has changed

See https://github.com/facebook/jest/issues/11444

`craco test` with cra5

```
Determining test suites to run...

  ● Test suite failed to run

    TypeError: babelJest.createTransformer is not a function

      at createJestBabelTransform (node_modules/@craco/craco/lib/features/jest/create-jest-babel-transform.js:56:22)
      at Object.<anonymous> (node_modules/@craco/craco/lib/features/jest/jest-babel-transform.js:9:8)
      at node_modules/@jest/transform/build/ScriptTransformer.js:383:73
```